### PR TITLE
reintroduce parallel

### DIFF
--- a/Workflows/ParallelWorkflow.js
+++ b/Workflows/ParallelWorkflow.js
@@ -2,15 +2,13 @@
 const { workflow } = require("zenaton");
 
 module.exports = workflow("ParallelWorkflow", async function() {
-  // We start 2 tasks asynchronously
-  const taskA = await this.dispatch.task("TaskA");
-  const taskB = await this.dispatch.task("TaskB");
-  // Then we wait for both completion
-  const [a, b] = await this.wait.completion(taskA, taskB).forever();
+  // We start 2 tasks synchronously
+  const [a, b] = await this.execute.task(["TaskA", 1], ["TaskB", 2]);
+
   // Then do something with both results
   if (a > b) {
-    await this.dispatch.task("TaskC");
+    await this.dispatch.task("TaskC", 3);
   } else {
-    await this.dispatch.task("TaskD");
+    await this.dispatch.task("TaskD", 4);
   }
 });

--- a/boot.js
+++ b/boot.js
@@ -8,13 +8,13 @@ require("./Workflows/ErrorWorkflow");
 require("./Workflows/VersionWorkflow_v0");
 require("./Workflows/VersionWorkflow_v1");
 require("./Workflows/VersionWorkflow_v2");
+require("./Workflows/ParallelWorkflow");
 
 require("./Tasks/TaskA");
 require("./Tasks/TaskB");
 require("./Tasks/TaskC");
 require("./Tasks/TaskD");
 require("./Tasks/TaskE");
-// require("./Workflows/ParallelWorkflow");
 
 require("./Recursive/RecursiveWorkflow");
 require("./Recursive/DisplayTask");


### PR DESCRIPTION
Reintroducing parallel executions on `execute` 

```
  const [a, b] = await this.execute.task(["TaskA", 1], ["TaskB", 2]);
```
